### PR TITLE
Add optional Attestix attestation for agent registration

### DIFF
--- a/nanda_adapter/core/agent_bridge.py
+++ b/nanda_adapter/core/agent_bridge.py
@@ -15,6 +15,7 @@ from python_a2a import (
 import asyncio
 from mcp_utils import MCPClient
 import base64
+import attestation
 
 import sys
 sys.stdout.reconfigure(line_buffering=True)
@@ -89,6 +90,10 @@ def register_with_registry(agent_id, agent_url, api_url):
             "agent_url": agent_url,
             "api_url": api_url
         }
+        proof = attestation.attest_registration(agent_id, agent_url)
+        if proof:
+            data["proof"] = proof
+            print(f"Attestix: attached registration proof (issuer {proof['issuer'][:24]}...)")
         print(f"Registering agent {agent_id} with URL {agent_url} at registry {registry_url}...")
         response = requests.post(f"{registry_url}/register", json=data)
         if response.status_code == 200:
@@ -109,6 +114,10 @@ def lookup_agent(agent_id):
         response = requests.get(f"{registry_url}/lookup/{agent_id}")
         if response.status_code == 200:
             agent_url = response.json().get("agent_url")
+            proof = response.json().get("proof")
+            if not attestation.verify_registration(agent_id, agent_url, proof):
+                print(f"WARNING: Attestix proof for agent {agent_id} failed verification - refusing URL")
+                return None
             print(f"Found agent {agent_id} at URL: {agent_url}")
             return agent_url
         print(f"Agent {agent_id} not found in registry")

--- a/nanda_adapter/core/attestation.py
+++ b/nanda_adapter/core/attestation.py
@@ -1,0 +1,90 @@
+# attestation.py
+"""Optional Attestix-backed attestation for NANDA agent registration.
+
+NANDA's registry binds an agent_id to a URL with no proof: any caller can POST
+any agent_id -> any URL, and lookups trust whatever the registry returns. This
+module lets an agent sign that binding (agent_id -> agent_url) with an Ed25519
+key, and lets peers verify it before trusting a looked-up URL.
+
+It is entirely opt-in:
+  * No ATTESTIX_AGENT_KEY set  -> attest_registration() returns None; behaviour
+    is byte-for-byte identical to today (unsigned registration).
+  * Key set but `attestix` not installed -> degrades to unsigned, with a notice.
+
+Enable: pip install nanda-adapter[attestix]
+Generate a key seed:
+    python -c "import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())"
+    export ATTESTIX_AGENT_KEY=<that value>
+"""
+import base64
+import os
+
+SUITE = "ed25519-jcs-2026"
+
+# ponytail: fail-open verification (missing proof -> accepted) so a signed agent
+# can still talk to the existing unsigned network. Set ATTESTIX_STRICT=1 to reject
+# any agent that presents no valid proof, once your peers all sign.
+STRICT = os.getenv("ATTESTIX_STRICT", "").lower() in ("1", "true", "yes")
+
+
+def _binding(agent_id, agent_url):
+    return {"agent_id": agent_id, "agent_url": agent_url}
+
+
+def _signing_key():
+    """Ed25519 private key from ATTESTIX_AGENT_KEY (base64url 32-byte seed), or None."""
+    raw = os.environ.get("ATTESTIX_AGENT_KEY")
+    if not raw:
+        return None
+    from attestix.auth.crypto import private_key_from_bytes
+    return private_key_from_bytes(base64.urlsafe_b64decode(raw))
+
+
+def attest_registration(agent_id, agent_url):
+    """Return a proof dict binding agent_id -> agent_url, or None if unconfigured."""
+    try:
+        key = _signing_key()
+        if key is None:
+            return None
+        from attestix.auth.crypto import public_key_to_did_key, sign_json_payload
+        return {
+            "suite": SUITE,
+            "issuer": public_key_to_did_key(key.public_key()),
+            "signature": sign_json_payload(key, _binding(agent_id, agent_url)),
+        }
+    except Exception as e:  # missing lib / bad key -> stay unsigned, never crash registration
+        print(f"Attestix: skipping registration proof ({e})")
+        return None
+
+
+def verify_registration(agent_id, agent_url, proof):
+    """True if a peer's (agent_id -> agent_url) binding is trustworthy.
+
+    No proof -> accepted unless ATTESTIX_STRICT (see STRICT above). A present
+    proof must be cryptographically valid AND bind exactly this agent_id+url.
+    """
+    if not proof:
+        return not STRICT
+    if proof.get("suite") != SUITE:
+        return False  # unknown suite -> can't verify it -> don't trust it
+    try:
+        from attestix.auth.crypto import did_key_to_public_key, verify_json_signature
+        pub = did_key_to_public_key(proof["issuer"])
+        return verify_json_signature(pub, _binding(agent_id, agent_url), proof["signature"])
+    except Exception as e:
+        print(f"Attestix: proof verification error ({e})")
+        return False
+
+
+if __name__ == "__main__":
+    # Runnable self-check of the security path (no attestix import needed if installed).
+    seed = base64.urlsafe_b64encode(bytes(range(32))).decode()
+    os.environ["ATTESTIX_AGENT_KEY"] = seed
+    p = attest_registration("agent-1", "https://a.example/a2a")
+    assert p and p["suite"] == SUITE, "should produce a proof when key is set"
+    assert verify_registration("agent-1", "https://a.example/a2a", p), "valid proof must verify"
+    assert not verify_registration("agent-1", "https://evil.example/a2a", p), "swapped URL must fail"
+    assert not verify_registration("agent-2", "https://a.example/a2a", p), "swapped id must fail"
+    assert not verify_registration("agent-1", "https://a.example/a2a", {**p, "suite": "other"}), "unknown suite must fail"
+    assert verify_registration("x", "y", None) is True, "no proof accepted in default (non-strict)"
+    print("attestation self-check OK")

--- a/nanda_adapter/examples/attestix_verified.py
+++ b/nanda_adapter/examples/attestix_verified.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Attestix-verified NANDA agent.
+
+NANDA's registry maps an agent_id to a URL with no proof of who owns it. This
+example shows how to make that binding verifiable: the agent signs its
+(agent_id -> agent_url) with an Ed25519 key, peers verify the signature before
+trusting a looked-up URL, and a spoofed entry is rejected.
+
+The attestation is opt-in and lives in nanda_adapter.core.attestation. Enable it
+by setting ATTESTIX_AGENT_KEY before starting any NANDA agent - no code change to
+your improvement logic is required.
+
+Run this file directly for an offline sign/verify demo (no API key, no registry):
+    pip install nanda-adapter[attestix]
+    python attestix_verified.py
+"""
+import base64
+import os
+
+# attestation is the new sibling module in nanda_adapter/core
+from nanda_adapter.core import attestation
+
+
+def generate_agent_key() -> str:
+    """Return a fresh base64url Ed25519 seed for ATTESTIX_AGENT_KEY."""
+    return base64.urlsafe_b64encode(os.urandom(32)).decode()
+
+
+def offline_demo():
+    """Prove the security property without a server or registry."""
+    # In production you persist this once and export it; here we make one on the fly.
+    os.environ["ATTESTIX_AGENT_KEY"] = generate_agent_key()
+
+    agent_id, agent_url = "pirate-agent-7", "https://pirate.example.com/a2a"
+
+    proof = attestation.attest_registration(agent_id, agent_url)
+    print(f"Signed registration proof:\n  issuer: {proof['issuer']}\n  suite:  {proof['suite']}\n")
+
+    # A peer who looks this agent up verifies the proof before trusting the URL.
+    print("honest lookup           ->", attestation.verify_registration(agent_id, agent_url, proof))
+    print("spoofed URL (attacker)  ->", attestation.verify_registration(agent_id, "https://evil.example/a2a", proof))
+    print("spoofed agent_id        ->", attestation.verify_registration("admin-agent", agent_url, proof))
+
+
+def run_verified_agent():
+    """Start a real NANDA agent whose registration is Attestix-signed.
+
+    Identical to any other example - the only difference is ATTESTIX_AGENT_KEY in
+    the environment, which makes register_with_registry() attach a proof and
+    lookup_agent() verify peers' proofs automatically.
+    """
+    from nanda_adapter import NANDA
+
+    if not os.getenv("ATTESTIX_AGENT_KEY"):
+        os.environ["ATTESTIX_AGENT_KEY"] = generate_agent_key()
+        print("No ATTESTIX_AGENT_KEY set - generated an ephemeral one for this run.")
+
+    def echo_logic(message_text: str) -> str:
+        return message_text
+
+    nanda = NANDA(echo_logic)
+    print("Starting Attestix-verified NANDA agent (registration will be signed)...")
+
+    domain = os.getenv("DOMAIN_NAME", "localhost")
+    if domain != "localhost":
+        nanda.start_server_api(os.getenv("ANTHROPIC_API_KEY"), domain)
+    else:
+        nanda.start_server()
+
+
+def main():
+    if os.getenv("RUN_AGENT"):
+        run_verified_agent()
+    else:
+        offline_demo()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
     extras_require={
         "langchain": ["langchain-core", "langchain-anthropic"],
         "crewai": ["crewai", "langchain-anthropic"],
-        "all": ["langchain-core", "langchain-anthropic", "crewai"]
+        "attestix": ["attestix>=0.4.0"],
+        "all": ["langchain-core", "langchain-anthropic", "crewai", "attestix>=0.4.0"]
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Problem

NANDA's registry binds an `agent_id` to a URL with no proof of ownership. In `register_with_registry()` the payload is just `{agent_id, agent_url, api_url}`, and `lookup_agent()` trusts whatever URL the registry returns. Any caller can register any `agent_id` pointing at any URL, and any peer will then route to a spoofed URL. The AgentFacts schema already reserves `certification` / `evaluations.auditTrail`, but nothing populates or verifies them today.

## Change

An **opt-in** Ed25519 proof over the `(agent_id, agent_url)` binding, signed with [Attestix](https://github.com/VibeTensor/attestix) (Apache-2.0, added only as an optional extra).

- **`core/attestation.py`** (new): `attest_registration()` signs the binding with the key in `ATTESTIX_AGENT_KEY`. `verify_registration()` checks a peer's proof and rejects an unknown signature suite. Fail-open by default for incremental rollout; `ATTESTIX_STRICT=1` rejects unsigned peers. Ships a runnable `__main__` self-check.
- **`core/agent_bridge.py`**: `register_with_registry()` attaches the proof (+4 lines); `lookup_agent()` verifies it and refuses a URL that fails (+4 lines); +1 import.
- **`examples/attestix_verified.py`**: offline sign/verify demo plus how to run a signed agent, mirroring `langchain_pirate.py` and `crewai_sarcastic.py`.
- **`setup.py`**: optional `[attestix]` extra.

## Why this shape

- **Backward-compatible:** no `ATTESTIX_AGENT_KEY` → byte-for-byte today's behaviour. Cannot break the existing unsigned network.
- **Tiny + localized:** 9-line change to `agent_bridge.py` + one self-contained module.
- **Complements #9 (Phala TEE):** TEE attests the *runtime*; this attests the *identity binding*. They stack.

## Verified

Tested against `attestix 0.4.1rc2` at three layers (module self-check; the real `register_with_registry`/`lookup_agent` with the registry mocked; and a true loopback E2E through a real HTTP socket):

- valid proof verifies; swapped URL rejected; swapped `agent_id` rejected; unknown suite rejected
- no-proof accepted in default mode, rejected under `ATTESTIX_STRICT`
- proof is JSON-serializable over the wire and a server-side tamper is refused over real HTTP

## Try it

```bash
pip install nanda-adapter[attestix]
python -m nanda_adapter.examples.attestix_verified      # offline sign/verify demo
# to sign a live agent's registration:
export ATTESTIX_AGENT_KEY=$(python -c "import os,base64;print(base64.urlsafe_b64encode(os.urandom(32)).decode())")
```

## Open question for maintainers

Does the registry **pass through extra `/register` fields** like `proof` and echo them on `/lookup`? If unknown keys are dropped server-side, the proof won't round-trip and verification falls back to the fail-open path (no protection, but no breakage). Happy to adjust to whatever field the registry preserves.

## Notes

- I don't see a `LICENSE` file in the repo (the `setup.py` classifier says MIT). Happy to sign any CLA you use.
- Open PRs #18 and #20 also touch `agent_bridge.py`; glad to rebase after either lands.

Opened as a **draft** for discussion, not asking for a merge yet.
